### PR TITLE
[fixed] 전시등록시 헤더 상태 변경적용 미비에 대한 대응 #dev

### DIFF
--- a/src/pages/CreateExhibition.jsx
+++ b/src/pages/CreateExhibition.jsx
@@ -8,10 +8,11 @@ import { headerStatedefalut } from "../components/headerStore";
 
 function CreateExhibition() {
   const [createExhibition] = usePostExhibition();
-  const [headerState, setHeaderState] = useRecoilState(headerStatedefalut)
-  useEffect(()=> {
-    setHeaderState({...headerState, exhibition:true})
-  },[])
+  const [, setHeaderState] = useRecoilState(headerStatedefalut);
+  const headerState = useAsyncValue(headerStateSearch)
+  useEffect(() => {
+    setHeaderState({ ...headerState, home: true });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
# 메인 v1.1
전시등록 페이지 이동시 헤더에서 이전 상태의 위치를 기억하고 있는 문제 해결